### PR TITLE
Fixed dll name in launch.json (Which will enable F5 debugging of project)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/bin/Debug/netcoreapp1.0/xunit-debugging.dll",
+            "program": "${workspaceRoot}/bin/Debug/netcoreapp1.0/dotnetcore-xunit-debugging.dll",
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false


### PR DESCRIPTION
When I was trying your example for xunit debugging in VS Code using F5, just got an error about debugger not attached. After some finding got it that dll name is not matching. Hence it was not attaching debugger. I fixed it in my branch and created pull request, hope you will merge it.

Thanks
Krunal.